### PR TITLE
Fix a bug where type_from_filename() does not run

### DIFF
--- a/src/fileaccess/fa_scanner.c
+++ b/src/fileaccess/fa_scanner.c
@@ -455,7 +455,7 @@ rescan(scanner_t *s)
       if(a->fde_stat.fs_mtime != b->fde_stat.fs_mtime) {
 	// Modification time has changed,  trig deep probe
 	a->fde_type = b->fde_type;
-	a->fde_probestatus = FDE_PROBE_FILENAME;
+	a->fde_probestatus = FDE_PROBE_NONE;
 	a->fde_stat = b->fde_stat;
 	a->fde_ignore_cache = 1;
 	changed = 1;


### PR DESCRIPTION
If the file is changed after it is in metadb
And the file type defaults to CONTENT_FILE instead
of the correct type.
This happens only for files recognized by their extension.
