### PR TITLE
fix MacOSX build

### DIFF
--- a/src/fileaccess/fa_buffer.c
+++ b/src/fileaccess/fa_buffer.c
@@ -125,7 +125,7 @@ dump_zones(const char *prefix, buffered_file_t *bf)
     if(bz->bz_size == 0)
       continue;
     printf("#%d  (%d +%d) => %ld\n",
-	   i, bz->bz_mpos, bz->bz_size, bz->bz_fpos);
+	   i, bz->bz_mpos, bz->bz_size, (long int)bz->bz_fpos);
   }
 }
 #endif


### PR DESCRIPTION
-Werror causes gcc to interrupt on MacOSX
Cast to (long int) so it will not interfere with oher platforms suach as PS3 and not generate warning on MacOSX
