### PR TITLE
After commit: "Make it possible to have multiple build outputs for a sing

### DIFF
--- a/configure.osx
+++ b/configure.osx
@@ -22,7 +22,7 @@ CPU=generic
 ARCH=`uname -m`
 MACOSXTARGET=""
 MACOSXSDK=""
-APPDIR=${BUILDDIR}/Showtime.app
+APPDIR=build.${BUILD}/Showtime.app
 
 show_help(){
   common_help


### PR DESCRIPTION
After commit: "Make it possible to have multiple build outputs for a single configure type" (6b99d8722d2268418532f8bf4805d3dc00cc862b)
MacOSX build was creating Showtime.app on Volume root  (/Showtime.app) and not in build.osx/Showtime.app
This commit sets APPDIR properly in build.osx/config.mak
It is needed to run ./configure.osx
