### PR TITLE
Fix thumbnail retrieval from blobCache, in thumbnail navigation

### DIFF
--- a/src/fileaccess/fa_imageloader.c
+++ b/src/fileaccess/fa_imageloader.c
@@ -520,7 +520,7 @@ fa_image_from_video(const char *url0, const image_meta_t *im,
   data = blobcache_get(cacheid, "videothumb", &datasize, 0, 0,
 		       NULL, &mtime);
   if(data != NULL && mtime == stattime) {
-    pm = pixmap_alloc_coded(data, datasize, CODEC_ID_PNG);
+    pm = pixmap_alloc_coded(data, datasize, PIXMAP_PNG);
     free(data);
     return pm;
   }


### PR DESCRIPTION
There was still a problem when loading thumbnails from blobcache.
i think this solves the problem.
