### PR TITLE
Fix a bug where showtime does not display the last subtitle entry

### DIFF
--- a/src/video/ext_subtitles.c
+++ b/src/video/ext_subtitles.c
@@ -271,7 +271,6 @@ load_srt(const char *url, const char *buf, size_t len, int force_utf8)
   }
 
   if(txt != NULL && pstart != -1 && pstop != -1) {
-    txt[txtoff] = 0;
     ese_insert(es, txt, pstart, pstop);
     txt = NULL;
   }


### PR DESCRIPTION
Hi,

  Showtime was not displaying the last subtitle entry, I think this solves the problem.

Regards,
Alexandre
