### PR TITLE
Use -iquote for local headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -597,7 +597,7 @@ OBJDIRS+= $(sort $(dir $(BUNDLE_OBJS)))
 # Common CFLAGS for all files
 CFLAGS_com += -g -funsigned-char ${OPTFLAGS} ${CFLAGS_dbg}
 CFLAGS_com += -D_FILE_OFFSET_BITS=64
-CFLAGS_com += -I${BUILDDIR} -I${CURDIR}/src -I${CURDIR}
+CFLAGS_com += -iquote${BUILDDIR} -iquote${CURDIR}/src -iquote${CURDIR}
 
 # Tools
 

--- a/ext/dvd/dvdcss/libdvdcss.h
+++ b/ext/dvd/dvdcss/libdvdcss.h
@@ -22,7 +22,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111, USA.
  *****************************************************************************/
 
-#include <fileaccess/svfs.h>
+#include "fileaccess/svfs.h"
 #include "showtime.h"
 
 struct iovec;

--- a/ext/dvd/dvdnav/dvdnav_internal.h
+++ b/ext/dvd/dvdnav/dvdnav_internal.h
@@ -49,7 +49,7 @@ static inline int _private_gettimeofday( struct timeval *tv, void *tz )
 
 #else
 
-#include <arch/threads.h>
+#include "arch/threads.h"
 
 #endif /* WIN32 */
 

--- a/ext/dvd/libdvdread/dvd_input.h
+++ b/ext/dvd/libdvdread/dvd_input.h
@@ -21,7 +21,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111, USA.
  */
 
-#include <fileaccess/svfs.h>
+#include "fileaccess/svfs.h"
 
 /**
  * Defines and flags.  Make sure they fit the libdvdcss API!

--- a/ext/dvd/libdvdread/dvd_reader.h
+++ b/ext/dvd/libdvdread/dvd_reader.h
@@ -24,7 +24,7 @@
 
 #include <sys/types.h>
 #include <inttypes.h>
-#include <fileaccess/svfs.h>
+#include "fileaccess/svfs.h"
 
 /**
  * The DVD access interface.

--- a/src/api/lastfm.c
+++ b/src/api/lastfm.c
@@ -20,8 +20,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <htsmsg/htsmsg.h>
-#include <htsmsg/htsmsg_xml.h>
+#include "htsmsg/htsmsg.h"
+#include "htsmsg/htsmsg_xml.h"
 
 #include "showtime.h"
 #include "lastfm.h"

--- a/src/api/lastfm.h
+++ b/src/api/lastfm.h
@@ -19,7 +19,7 @@
 #ifndef LASTFM_H__
 #define LASTFM_H__
 
-#include <misc/rstr.h>
+#include "misc/rstr.h"
 
 struct prop;
 

--- a/src/api/opensubtitles.c
+++ b/src/api/opensubtitles.c
@@ -19,8 +19,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <htsmsg/htsmsg.h>
-#include <htsmsg/htsmsg_xml.h>
+#include "htsmsg/htsmsg.h"
+#include "htsmsg/htsmsg_xml.h"
 
 #include "showtime.h"
 #include "opensubtitles.h"

--- a/src/api/xmlrpc.c
+++ b/src/api/xmlrpc.c
@@ -19,7 +19,7 @@
 #include <string.h>
 #include <stdio.h>
 
-#include <htsmsg/htsmsg_xml.h>
+#include "htsmsg/htsmsg_xml.h"
 
 #include "fileaccess/fileaccess.h" // HTTP client lives here
 

--- a/src/api/xmlrpc.h
+++ b/src/api/xmlrpc.h
@@ -19,7 +19,7 @@
 #ifndef XMLRPC_H__
 #define XMLRPC_H__
 
-#include <htsmsg/htsmsg.h>
+#include "htsmsg/htsmsg.h"
 
 htsmsg_t *xmlrpc_request(const char *url, const char *method, htsmsg_t *params,
 			 char *errbuf, size_t errlen);

--- a/src/arch/nspr/nspr.c
+++ b/src/arch/nspr/nspr.c
@@ -3,7 +3,7 @@
 #include "prcvar.h"
 #include "prthread.h"
 
-#include <arch/atomic.h>
+#include "arch/atomic.h"
 #include <stdlib.h>
 
 PRInt32

--- a/src/arch/nspr/prtypes.h
+++ b/src/arch/nspr/prtypes.h
@@ -2,7 +2,7 @@
 #define PRTYPES_H__
 
 #include <stdint.h>
-#include <arch/threads.h>
+#include "arch/threads.h"
 
 typedef hts_mutex_t PRLock;
 

--- a/src/backend/dvd/dvd.c
+++ b/src/backend/dvd/dvd.c
@@ -28,8 +28,8 @@
 
 #include <libavcodec/avcodec.h>
 
-#include <fileaccess/svfs.h>
-#include <dvdnav/dvdnav.h>
+#include "fileaccess/svfs.h"
+#include "dvdnav/dvdnav.h"
 
 static char *make_nice_title(const char *t);
 

--- a/src/backend/htsp/htsp.c
+++ b/src/backend/htsp/htsp.c
@@ -21,10 +21,10 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <htsmsg/htsmsg.h>
-#include <htsmsg/htsmsg_binary.h>
-#include <arch/threads.h>
-#include <arch/atomic.h>
+#include "htsmsg/htsmsg.h"
+#include "htsmsg/htsmsg_binary.h"
+#include "arch/threads.h"
+#include "arch/atomic.h"
 
 #include <libavcodec/avcodec.h>
 

--- a/src/bookmarks.c
+++ b/src/bookmarks.c
@@ -22,7 +22,7 @@
 #include <unistd.h>
 #include <stdio.h>
 
-#include <htsmsg/htsmsg_store.h>
+#include "htsmsg/htsmsg_store.h"
 
 #include "showtime.h"
 #include "service.h"

--- a/src/fileaccess/fa_buffer.c
+++ b/src/fileaccess/fa_buffer.c
@@ -22,7 +22,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <arch/halloc.h>
+#include "arch/halloc.h"
 
 #include "showtime.h"
 #include "fileaccess.h"

--- a/src/fileaccess/fa_spotlight.c
+++ b/src/fileaccess/fa_spotlight.c
@@ -26,7 +26,7 @@
 #include "fa_search.h"
 #include "service.h"
 #include "settings.h"
-#include "metadata.h"
+#include "metadata/metadata.h"
 
 static int spotlight_enabled;
 

--- a/src/fileaccess/fileaccess.c
+++ b/src/fileaccess/fileaccess.c
@@ -36,7 +36,7 @@
 #include "fileaccess.h"
 #include "backend/backend.h"
 
-#include <fileaccess/svfs.h>
+#include "fileaccess/svfs.h"
 
 #include "fa_proto.h"
 #include "fa_probe.h"

--- a/src/htsmsg/htsmsg_store.h
+++ b/src/htsmsg/htsmsg_store.h
@@ -19,7 +19,7 @@
 #ifndef HTSMSG_STORE_H__
 #define HTSMSG_STORE_H__
 
-#include <htsmsg/htsmsg.h>
+#include "htsmsg/htsmsg.h"
 #include <stdarg.h>
 
 void htsmsg_store_init(void);

--- a/src/ipc/stdin.c
+++ b/src/ipc/stdin.c
@@ -22,9 +22,9 @@
 #include <termios.h>
 #include <string.h>
 
-#include <arch/threads.h>
-#include <event.h>
-#include <ui/ui.h>
+#include "arch/threads.h"
+#include "event.h"
+#include "ui/ui.h"
 
 #include "ipc.h"
 

--- a/src/keyring.c
+++ b/src/keyring.c
@@ -20,7 +20,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <inttypes.h>
-#include <htsmsg/htsmsg_store.h>
+#include "htsmsg/htsmsg_store.h"
 
 #include "showtime.h"
 #include "event.h"

--- a/src/media.h
+++ b/src/media.h
@@ -20,7 +20,7 @@
 #define MEDIA_H
 
 #include <stdlib.h>
-#include <arch/atomic.h>
+#include "arch/atomic.h"
 #include "prop/prop.h"
 #include "event.h"
 #include "misc/pool.h"

--- a/src/metadata/metadata.h
+++ b/src/metadata/metadata.h
@@ -16,8 +16,8 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <misc/queue.h>
-#include <misc/rstr.h>
+#include "misc/queue.h"
+#include "misc/rstr.h"
 
 #pragma once
 

--- a/src/misc/pixmap.c
+++ b/src/misc/pixmap.c
@@ -17,7 +17,7 @@
  */
 
 #include <sys/param.h>
-#include <arch/atomic.h>
+#include "arch/atomic.h"
 #include <string.h>
 #include <stdlib.h>
 #include "pixmap.h"

--- a/src/misc/pool.c
+++ b/src/misc/pool.c
@@ -20,8 +20,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <arch/halloc.h>
-#include <arch/threads.h>
+#include "arch/halloc.h"
+#include "arch/threads.h"
 
 #include "queue.h"
 #include "showtime.h"

--- a/src/networking/net.h
+++ b/src/networking/net.h
@@ -35,7 +35,7 @@
 
 #include <sys/types.h>
 #include <stdint.h>
-#include <htsmsg/htsbuf.h>
+#include "htsmsg/htsbuf.h"
 
 typedef struct tcpcon {
   int fd;

--- a/src/prop/prop_core.c
+++ b/src/prop/prop_core.c
@@ -24,7 +24,7 @@
 #include <unistd.h>
 #include <math.h>
 
-#include <arch/atomic.h>
+#include "arch/atomic.h"
 
 #include "showtime.h"
 #include "prop_i.h"

--- a/src/prop/prop_grouper.c
+++ b/src/prop/prop_grouper.c
@@ -24,7 +24,7 @@
 #include <unistd.h>
 #include <math.h>
 
-#include <arch/atomic.h>
+#include "arch/atomic.h"
 
 #include "showtime.h"
 #include "prop_i.h"

--- a/src/prop/prop_nodefilter.c
+++ b/src/prop/prop_nodefilter.c
@@ -24,7 +24,7 @@
 #include <unistd.h>
 #include <math.h>
 
-#include <arch/atomic.h>
+#include "arch/atomic.h"
 
 #include "showtime.h"
 #include "prop_i.h"

--- a/src/settings.h
+++ b/src/settings.h
@@ -20,7 +20,7 @@
 #define SETTINGS_H__
 
 #include "prop/prop.h"
-#include <htsmsg/htsmsg.h>
+#include "htsmsg/htsmsg.h"
 
 #define SETTINGS_INITIAL_UPDATE 0x1
 #define SETTINGS_PASSWORD       0x2 // Make a password entry (hidden display)

--- a/src/showtime.h
+++ b/src/showtime.h
@@ -23,8 +23,8 @@
 #include <stdarg.h>
 #include <string.h>
 #include <sys/time.h>
-#include <htsmsg/htsmsg_store.h>
-#include <arch/threads.h>
+#include "htsmsg/htsmsg_store.h"
+#include "arch/threads.h"
 
 // NLS
 

--- a/src/ui/glw/glw.c
+++ b/src/ui/glw/glw.c
@@ -24,7 +24,7 @@
 
 #include "keymapper.h"
 
-#include <arch/threads.h>
+#include "arch/threads.h"
 
 #include "glw.h"
 #include "glw_text_bitmap.h"

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -18,7 +18,7 @@
 
 #include <string.h>
 #include <stdio.h>
-#include <arch/threads.h>
+#include "arch/threads.h"
 
 #include "showtime.h"
 #include "event.h"


### PR DESCRIPTION
By using -iquote for local headers files system headers can
not unintentionally include local header files with same name.

Not sure it this is a good solution. Another solution could be to move "arch", "htsmsg" and other system-like things to a new directory that we have -I path to.

Have only test built on Mac OS X, there are probably more files that need to be changed.
