### PR TITLE
Clang fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ include support/${PLATFORM}.mk
 
 # Bundle files
 $(BUILDDIR)/bundles/%.o: $(BUILDDIR)/bundles/%.c Makefile
-	$(CC) -I${CURDIR}/src/fileaccess -c -o $@ $<
+	$(CC) $(CFLAGS) $(CFLAGS_cfg) -I${CURDIR}/src/fileaccess -c -o $@ $<
 
 $(BUILDDIR)/bundles/%.c: % $(CURDIR)/support/mkbundle Makefile
 	$(MKBUNDLE) -o $@ -s $< -d ${BUILDDIR}/bundles/$<.d -p $<

--- a/src/backend/rtmp/rtmp.c
+++ b/src/backend/rtmp/rtmp.c
@@ -325,7 +325,7 @@ sendpkt(rtmp_t *r, media_queue_t *mq, media_codec_t *mc,
  *
  */
 static event_t *
-get_packet_v(rtmp_t *r, uint8_t *data, size_t size, int64_t dts,
+get_packet_v(rtmp_t *r, uint8_t *data, int size, int64_t dts,
 	     media_pipe_t *mp)
 {
   uint8_t flags;
@@ -427,7 +427,7 @@ get_packet_v(rtmp_t *r, uint8_t *data, size_t size, int64_t dts,
  *
  */
 static event_t *
-get_packet_a(rtmp_t *r, uint8_t *data, size_t size, int64_t dts, 
+get_packet_a(rtmp_t *r, uint8_t *data, int size, int64_t dts, 
 	     media_pipe_t *mp)
 {
   uint8_t flags;

--- a/src/fileaccess/fa_buffer.c
+++ b/src/fileaccess/fa_buffer.c
@@ -247,7 +247,7 @@ fab_seek(fa_handle_t *handle, int64_t pos, int whence)
 {
   buffered_file_t *bf = (buffered_file_t *)handle;
   fa_handle_t *src = bf->bf_src;
-  uint64_t np;
+  int64_t np;
 
   switch(whence) {
   case SEEK_SET:

--- a/src/fileaccess/fa_imageloader.c
+++ b/src/fileaccess/fa_imageloader.c
@@ -257,7 +257,7 @@ fa_imageloader(const char *url, const struct image_meta *im,
     return NULL;
   }
 
-  size_t s = fa_fsize(fh);
+  int64_t s = fa_fsize(fh);
   if(s < 0) {
     snprintf(errbuf, errlen, "Can't read from non-seekable file");
     fa_close(fh);

--- a/src/metadata/metadata.c
+++ b/src/metadata/metadata.c
@@ -120,7 +120,7 @@ static const char *types[] = {
 const char *
 content2type(contenttype_t ctype)
 {
-  if (ctype < 0 || ctype >= sizeof(types) / sizeof(types[0]))
+  if (ctype >= sizeof(types) / sizeof(types[0]))
     return NULL;
 
   return types[ctype];

--- a/src/misc/json.c
+++ b/src/misc/json.c
@@ -17,6 +17,7 @@
  */
 
 #include <stdlib.h>
+#include <stddef.h>
 #include <string.h>
 #include <limits.h>
 #include <stdio.h>
@@ -409,7 +410,7 @@ json_deserialize(const char *src, const json_deserializer_t *jd, void *opaque,
 
   if(c == NULL) {
     size_t len = strlen(src);
-    size_t offset = errp - src;
+    ptrdiff_t offset = errp - src;
     if(offset > len || offset < 0) {
       snprintf(errbuf, errlen, "%s at (bad) offset %zd", errmsg, offset);
     } else {

--- a/src/service.c
+++ b/src/service.c
@@ -287,7 +287,7 @@ service_probe_loop(void *aux)
       url = strdup(s->s_url);
 
       hts_mutex_unlock(&service_mutex);
-      st = backend_probe(url, txt, sizeof(txt)); // Can take a lot of time
+      st = (service_status_t)backend_probe(url, txt, sizeof(txt)); // Can take a lot of time
       free(url);
       hts_mutex_lock(&service_mutex);
     }

--- a/src/text/freetype.c
+++ b/src/text/freetype.c
@@ -313,7 +313,7 @@ face_create_from_uri(const char *path)
   char errbuf[256];
   FT_Open_Args oa = {0};
   FT_Error err;
-  size_t s;
+  int64_t s;
 
   fa_handle_t *fh = fa_open(path, errbuf, sizeof(errbuf));
   if(fh == NULL) {

--- a/src/ui/glw/glw_event.c
+++ b/src/ui/glw/glw_event.c
@@ -404,7 +404,9 @@ glw_event_map_internal_fire(glw_t *w, glw_event_map_t *gem, event_t *src)
   glw_t *t;
   event_t *e;
 
-  e = event_create_action(g->event);
+  // TODO: is the idea that event_type_t and action_type_t can be cased back
+  // and forth? (they dont seam to overlap)
+  e = event_create_action((action_type_t)g->event);
   e->e_mapped = 1;
 
   if(g->target != NULL) {

--- a/src/ui/glw/glw_math_sse.h
+++ b/src/ui/glw/glw_math_sse.h
@@ -1,3 +1,5 @@
+#include <smmintrin.h>
+
 static inline void
 glw_Translatef(glw_rctx_t *rc, float x, float y, float z)
 {
@@ -73,14 +75,14 @@ typedef Mtx PMtx;
 
 #define glw_pmtx_mul_prepare(dst, src) do {				\
     __v4sf __r0 = (src)[0], __r1 = (src)[1], __r2 = (src)[2], __r3 = (src)[3]; \
-    __v4sf __t0 = __builtin_ia32_unpcklps (__r0, __r1);			\
-    __v4sf __t1 = __builtin_ia32_unpcklps (__r2, __r3);			\
-    __v4sf __t2 = __builtin_ia32_unpckhps (__r0, __r1);			\
-    __v4sf __t3 = __builtin_ia32_unpckhps (__r2, __r3);			\
-    (dst)[0] = __builtin_ia32_movlhps (__t0, __t1);			\
-    (dst)[1] = __builtin_ia32_movhlps (__t1, __t0);			\
-    (dst)[2] = __builtin_ia32_movlhps (__t2, __t3);			\
-    (dst)[3] = __builtin_ia32_movhlps (__t3, __t2);			\
+    __v4sf __t0 = _mm_unpacklo_ps (__r0, __r1);			\
+    __v4sf __t1 = _mm_unpacklo_ps (__r2, __r3);			\
+    __v4sf __t2 = _mm_unpacklo_ps (__r0, __r1);			\
+    __v4sf __t3 = _mm_unpacklo_ps (__r2, __r3);			\
+    (dst)[0] = _mm_movelh_ps (__t0, __t1);			\
+    (dst)[1] = _mm_movehl_ps (__t1, __t0);			\
+    (dst)[2] = _mm_movelh_ps (__t2, __t3);			\
+    (dst)[3] = _mm_movehl_ps (__t3, __t2);			\
   } while (0)
 
 
@@ -95,9 +97,9 @@ typedef Mtx PMtx;
 
 #define glw_pmtx_mul_vec3(dst, pmt, V) do {			\
     __v4sf v = _mm_set_ps(1,					\
-			  __builtin_ia32_vec_ext_v4sf(V, 2),	\
-			  __builtin_ia32_vec_ext_v4sf(V, 1),	\
-			  __builtin_ia32_vec_ext_v4sf(V, 0));	\
+			  _mm_extract_ps(V, 2),	\
+			  _mm_extract_ps(V, 1),	\
+			  _mm_extract_ps(V, 0));	\
     __v4sf a0 = _mm_mul_ps(pmt[0], v);				\
     __v4sf a1 = _mm_mul_ps(pmt[1], v);				\
     __v4sf a2 = _mm_mul_ps(pmt[2], v);				\
@@ -133,26 +135,26 @@ static inline float glw_vec3_dot(const Vec3 a, const Vec3 b)
 {
   __v4sf n = _mm_mul_ps(a,b);
   return 
-    __builtin_ia32_vec_ext_v4sf(n, 0) + 
-    __builtin_ia32_vec_ext_v4sf(n, 1) + 
-    __builtin_ia32_vec_ext_v4sf(n, 2);
+    _mm_extract_ps(n, 0) + 
+    _mm_extract_ps(n, 1) + 
+    _mm_extract_ps(n, 2);
 }
 
 static inline float glw_vec34_dot(const Vec3 a, const Vec4 b)
 {
   __v4sf n = _mm_mul_ps(a,b);
   return 
-    __builtin_ia32_vec_ext_v4sf(n, 0) + 
-    __builtin_ia32_vec_ext_v4sf(n, 1) + 
-    __builtin_ia32_vec_ext_v4sf(n, 2) + 
-    __builtin_ia32_vec_ext_v4sf(b, 3);
+    _mm_extract_ps(n, 0) + 
+    _mm_extract_ps(n, 1) + 
+    _mm_extract_ps(n, 2) + 
+    _mm_extract_ps(b, 3);
 }
 
 extern int glw_mtx_invert(Mtx dst, const Mtx src);
 
-#define glw_vec3_extract(a, pos)  __builtin_ia32_vec_ext_v4sf(a, pos)
+#define glw_vec3_extract(a, pos)  _mm_extract_ps(a, pos)
 
-#define glw_vec4_extract(a, pos) __builtin_ia32_vec_ext_v4sf(a, pos)
+#define glw_vec4_extract(a, pos) _mm_extract_ps(a, pos)
 
 const static inline float *
 glw_mtx_get(const Mtx src)


### PR DESCRIPTION
Fixes some unsigned < 0 always false warnings.
Don't know if the vector stuff i correct or works with GCC yet.

This also got me thinking about that apple dont boudle X11 with new installtions, so me might need to fix the freetype stuff again. I did some hacking on making it work a bit like ext/libav.
