### PR TITLE
Subtitle timeout

### DIFF
--- a/src/ui/glw/glw_video_overlay.c
+++ b/src/ui/glw/glw_video_overlay.c
@@ -44,6 +44,7 @@ typedef struct glw_video_overlay {
 
   int64_t gvo_start;
   int64_t gvo_stop;
+  int gvo_stop_estimated;
 
   int gvo_fadein;
   int gvo_fadeout;
@@ -126,7 +127,7 @@ gvo_flush_infinite(glw_video_t *gv)
   for(gvo = LIST_FIRST(&gv->gv_overlays); gvo != NULL; gvo = next) {
     next = LIST_NEXT(gvo, gvo_link);
 
-    if(gvo->gvo_stop == AV_NOPTS_VALUE)
+    if(gvo->gvo_stop == AV_NOPTS_VALUE || gvo->gvo_stop_estimated)
       gvo_destroy(gv, gvo);
   }
 }
@@ -718,6 +719,7 @@ gvo_create_from_vo_text(glw_video_t *gv, video_overlay_t *vo)
   glw_video_overlay_t *gvo = gvo_create(vo->vo_start, GVO_TEXT);
 
   gvo->gvo_stop           = vo->vo_stop;
+  gvo->gvo_stop_estimated = vo->vo_stop_estimated;
   gvo->gvo_fadein         = vo->vo_fadein;
   gvo->gvo_fadeout        = vo->vo_fadeout;
   gvo->gvo_canvas_width   = vo->vo_canvas_width;
@@ -786,13 +788,13 @@ glw_video_overlay_sub_set_pts(glw_video_t *gv, int64_t pts)
 	break;
       gvo_flush_infinite(gv);
       if(vo->vo_pixmap != NULL)
-	gvo_create_from_vo_bitmap(gv, vo);
+        gvo_create_from_vo_bitmap(gv, vo);
       video_overlay_destroy(vd, vo);
       continue;
 
     case VO_TEXT:
       if(vo->vo_start > pts)
-	break;
+        break;
       gvo_flush_infinite(gv);
       gvo_create_from_vo_text(gv, vo);
       video_overlay_destroy(vd, vo);

--- a/src/video/video_overlay.c
+++ b/src/video/video_overlay.c
@@ -112,10 +112,12 @@ video_overlay_render_cleartext(video_decoder_t *vd, const char *txt,
 			       int64_t start, int64_t stop, int tags)
 {
   uint32_t *uc;
-  int len;
+  int len, txt_len;
   video_overlay_t *vo;
-
-  if(strlen(txt) == 0) {
+  
+  txt_len = strlen(txt);
+  
+  if(txt_len == 0) {
     vo = calloc(1, sizeof(video_overlay_t));
   } else {
 
@@ -139,11 +141,26 @@ video_overlay_render_cleartext(video_decoder_t *vd, const char *txt,
     vo->vo_text_length = len;
     vo->vo_padding_left = -1;  // auto padding
   }
+
+  if(stop == AV_NOPTS_VALUE) {
+    stop = start + calculate_subtitle_duration(txt_len) * 1000000;
+    vo->vo_stop_estimated = 1;
+  }
   
   vo->vo_start = start;
   vo->vo_stop = stop;
-
+  
   video_overlay_enqueue(vd, vo);
+}
+
+/**
+ * Calculate the number of seconds a subtitle should be displayed.
+ * Min 2 seconds, max 7 seconds. 
+ */
+int
+calculate_subtitle_duration(int txt_len) 
+{
+  return 2 + (txt_len / 74.0F) * 5; //74 is the maximum amount of characters a subtitler may fit on 2 lines of text.
 }
 
 

--- a/src/video/video_overlay.h
+++ b/src/video/video_overlay.h
@@ -21,6 +21,7 @@ typedef struct video_overlay {
 
   int64_t vo_start;
   int64_t vo_stop;
+  int vo_stop_estimated;
 
   int vo_x;
   int vo_y;
@@ -61,3 +62,5 @@ void video_overlay_decode_ext_subtitle(video_decoder_t *vd,
 
 void video_overlay_render_cleartext(video_decoder_t *vd, const char *txt,
 				    int64_t start, int64_t stop, int tags);
+
+int calculate_subtitle_duration(int txt_len);


### PR DESCRIPTION
Some subtitles are missing a duration, for example textsubs from tvheadend.
This patch estimates an appropriate display time, depending on the subtitle length.
GLW overlay objects with estimated durations are cleaned up just like infinite objects, to make way for the next subtitle if they happen to overlap.
