### PR TITLE
glw: Add Background support to Item view

### DIFF
--- a/glwthemes/mono/pages/item.view
+++ b/glwthemes/mono/pages/item.view
@@ -20,6 +20,12 @@
   });
 }
 
+widget(container_z, {
+    widget(backdrop, {
+        .source = $page.model.metadata.background;
+	.alpha = 0.6;
+    });
+
 widget(container_y, {
    .alpha = 1 - iir(clamp(getLayer(), 0, 1), 7) * 0.5;
    .blur  = iir(clamp(getLayer(), 0, 1), 7);
@@ -66,5 +72,6 @@ widget(container_y, {
       }));
     });
   });
+});
 });
 


### PR DESCRIPTION
It uses alpha 0.6 in order to make it possible to read easily on backgrounds with intense lightning
