### PR TITLE
move Seek by t ime as first option in menu, this improves usability

### DIFF
--- a/glwthemes/default/cmdmenu/cmdmenu_video.view
+++ b/glwthemes/default/cmdmenu/cmdmenu_video.view
@@ -15,6 +15,11 @@ widget(deck, {
 
     SEP(_("Video menu"));
 
+    ITEM(_("Seek by time"), {
+      $view.page = 6;
+    }, "dataroot://resources/svg/SeekByFrame.svg",
+   $global.media.current.seekindex.available);
+
     ITEM(_("Audio tracks"), {
       $view.page = 1;
     }, "dataroot://resources/svg/Music.svg");
@@ -22,11 +27,6 @@ widget(deck, {
     ITEM(_("Subtitle tracks"), {
       $view.page = 2;
     }, "dataroot://resources/svg/Script.svg");
-
-    ITEM(_("Seek by time"), {
-      $view.page = 6;
-    }, "dataroot://resources/svg/SeekByFrame.svg",
-	 $global.media.current.seekindex.available);
 
     SEP(_("Settings"));
 


### PR DESCRIPTION
Hi, Moving "seek by time" as first option in menu makes usability better.
