### PR TITLE
Update lang/it_IT.lang

### DIFF
--- a/lang/it_IT.lang
+++ b/lang/it_IT.lang
@@ -232,6 +232,9 @@ msg: Rimuovi
 id: Plugins
 msg: Plugins
 
+id: Search / Open URL
+msg: Cerca / Apri URL
+
 #
 # ./glwskins/default/pages/iteminfo/image.view
 #
@@ -332,8 +335,7 @@ msg: Traccia %d / %d
 # ./glwskins/default/pages/slideshow.view
 #
 id: Paused
-# Missing translation
-msg: 
+msg: In Pausa
 
 #
 # ./glwskins/default/pages/upgrade.view
@@ -397,13 +399,6 @@ msg: CPU troppo lenta per poter decodificare questo video
 
 id: Playback status
 msg: Stato di riproduzione
-
-#
-# ./glwskins/default/pages/wideinfo/video.view
-#
-id: Seen:
-# Missing translation
-msg: 
 
 #
 # ./glwskins/default/playdecks/dvd.view
@@ -666,11 +661,20 @@ msg: Accesso fallito
 #
 # ./src/fileaccess/fa_scanner.c
 #
+id: Artists
+msg: Artisti
+
 id: Date
 msg: Data
 
 id: Filename
 msg: Nome file
+
+id: Indexed mode
+msg: Modalità indicizzata
+
+id: Off
+msg: Disattiva
 
 id: Show only supported files
 msg: Mostra solo file supportati
@@ -778,6 +782,12 @@ id: Video zoom
 msg: Zoom video
 
 #
+# ./src/metadata/browsemdb.c
+#
+id: Indexing
+msg: Indicizzando
+
+#
 # ./src/metadata/metadata.c
 #
 id: Automatic
@@ -865,8 +875,7 @@ msg: Pulire tutti i metadata significa perdere <b>tutte</b> le informazioni rigu
 # ./src/navigator.c
 #
 id: Add and remove items on homepage
-# Missing translation
-msg: 
+msg: Aggiungi e rimuovi oggetti sulla homepage
 
 id: Added new bookmark: %s
 msg: Aggiunto nuovo segnalibro: %s
@@ -914,19 +923,16 @@ id: Available plugins
 msg: Plugin disponibili
 
 id: Background
-# Missing translation
-msg: 
+msg: Sfondo
 
 id: Beta testing passwords
-# Missing translation
-msg: 
+msg: Password di beta testing
 
 id: Browse available plugins
 msg: Sfoglia i plugin disponibili
 
 id: Browsing
-# Missing translation
-msg: 
+msg: Sfogliando
 
 id: Cloud services
 msg: Servizi Cloud
@@ -935,8 +941,7 @@ id: Corrupt plugin bundle
 msg: Bundle di plugin corrotto
 
 id: Default
-# Missing translation
-msg: 
+msg: Default
 
 id: Disk write error
 msg: Errore di scrittura su disco
@@ -948,30 +953,25 @@ id: File open error
 msg: Errore d'apertura del file
 
 id: Home page
-# Missing translation
-msg: 
+msg: Pagina Iniziale
 
 id: Installed plugins
 msg: Plugin installati
 
 id: Installed version higher than available
-# Missing translation
-msg: 
+msg: La versione installa è più recente di quella disponibile
 
 id: Installing
 msg: Installazione
 
 id: List of albums
-# Missing translation
-msg: 
+msg: Elenco degli album
 
 id: Loading screen
-# Missing translation
-msg: 
+msg: Schermata di caricamento
 
 id: Movies
-# Missing translation
-msg: 
+msg: Film
 
 id: Music streaming
 msg: Streaming di musica
@@ -989,16 +989,13 @@ id: Online TV
 msg: TV online
 
 id: Preferred views from plugins
-# Missing translation
-msg: 
+msg: Visualizzazioni preferite dai plugin
 
 id: Screen saver
-# Missing translation
-msg: 
+msg: Salvaschermo
 
 id: TV channels
-# Missing translation
-msg: 
+msg: Canali TV
 
 id: Unable to load plugin.json: %s
 msg: Impossibile caricare plugin.json: %s
@@ -1067,8 +1064,7 @@ id: Discovered media sources
 msg: Sorgenti media trovate
 
 id: Fonts and user interface styling
-# Missing translation
-msg: 
+msg: Stile dell'interfaccia e caratteri
 
 id: General
 msg: Generale
@@ -1077,8 +1073,7 @@ id: Global settings
 msg: Impostazioni globali
 
 id: Look and feel
-# Missing translation
-msg: 
+msg: Aspetto e comportamento
 
 id: Settings useful for developers
 msg: Impostazioni utili per sviluppatori
@@ -1089,8 +1084,26 @@ msg: Impostazioni relative al sistema
 #
 # ./src/text/fontstash.c
 #
+id: Defaults
+msg: Default
+
+id: Fonts
+msg: Caratteri
+
+id: Installed fonts
+msg: Caratteri installati
+
 id: Narrow text
 msg: Narrow text
+
+id: Reset main font to default
+msg: Ripristina carattere principale di default
+
+id: Reset narrow font to default
+msg: Ripristina carattere stretto di default
+
+id: Reset subtitle font to default
+msg: Ripristina carattere sottotitoli di default
 
 id: Unable to load %s -- %s
 msg: Impossibile caricare %s -- %s
@@ -1256,9 +1269,6 @@ msg: Risoluzione massima per il deinterlacciatore
 
 id: No limit
 msg: Nessun limite
-
-id: Off
-msg: Disattiva
 
 id: Outline color
 msg: Colore contorni


### PR DESCRIPTION
Fixed the following missing translations:
 ! Missing translation for Search / Open URL
 ! Missing translation for Paused
 ! Missing translation for Artists
 ! Missing translation for Indexed mode
 ! Missing translation for Indexing
 ! Missing translation for Add and remove items on homepage
 ! Missing translation for Background
 ! Missing translation for Beta testing passwords
 ! Missing translation for Browsing
 ! Missing translation for Default
 ! Missing translation for Home page
 ! Missing translation for Installed version higher than available
 ! Missing translation for List of albums
 ! Missing translation for Loading screen
 ! Missing translation for Movies
 ! Missing translation for Preferred views from plugins
 ! Missing translation for Screen saver
 ! Missing translation for TV channels
 ! Missing translation for Fonts and user interface styling
 ! Missing translation for Look and feel
 ! Missing translation for Defaults
 ! Missing translation for Fonts
 ! Missing translation for Installed fonts
 ! Missing translation for Reset main font to default
 ! Missing translation for Reset narrow font to default
 ! Missing translation for Reset subtitle font to default
