### PR TITLE
ccache checking fix and dpkg-buildpackage dependency fix

### DIFF
--- a/Autobuild/debian.sh
+++ b/Autobuild/debian.sh
@@ -17,15 +17,16 @@ VER=`git describe | sed "s/\([0-9]*\)\.\([0-9]*\)-\([0-9]*\)-.*/\1.\2.\3/"`
     export JARGS
     export ARCH
 
-    which ccache >/dev/null
-    if [ $? -eq 0 ]; then
+    if ccache=$(which ccache); then
 	echo "Using ccache"
 	ccache -s
 	USE_CCACHE="--ccache"
     else
 	USE_CCACHE=""
     fi
+
     export USE_CCACHE
+
 
     dpkg-buildpackage -b -us -uc
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: showtime
 Section: main
 Priority: extra
 Maintainer: Andreas Öman <andreas@lonelycoder.com>
-Build-Depends: debhelper  (>= 7.0.50), pkg-config, libfreetype6-dev, libfontconfig1-dev, libx11-dev, libxext-dev, libgl1-mesa-dev, libasound-dev, libpulse-dev, libgtk2.0-dev, libxss-dev, libxxf86vm-dev, libxv-dev, libcdio-cdda-dev, libssl-dev, libvdpau-dev, yasm, curl, libsqlite3-dev, libwebkitgtk-dev
+Build-Depends: debhelper  (>= 7.0.50), pkg-config, libfreetype6-dev, libfontconfig1-dev, libx11-dev, libxext-dev, libgl1-mesa-dev, libasound-dev, libpulse-dev, libgtk2.0-dev, libxss-dev, libxxf86vm-dev, libxv-dev, libcdio-cdda-dev, libssl-dev, libvdpau-dev, yasm, curl, libsqlite3-dev, libwebkitgtk-dev, dpkg-dev
 
 Package: showtime
 Section: main


### PR DESCRIPTION
If ccache does not exist Autobuild would fail. 
Added dpkg-dev depencendy needed by dpkg-buildpackage.
