### PR TITLE
android: improve remote control handling

### DIFF
--- a/src/arch/android/android_glw.c
+++ b/src/arch/android/android_glw.c
@@ -308,6 +308,10 @@ Java_com_lonelycoder_mediaplayer_Core_glwKeyDown(JNIEnv *env,
   glw_root_t *gr = &agr->gr;
   event_t *e = NULL;
 
+  // along with AKEYCODE_ENTER usually passed Line Feed char - 10
+  if(keycode == AKEYCODE_ENTER)
+    unicode = 0;
+
   if(gconf.enable_input_event_debug)
     TRACE(TRACE_DEBUG, "KEYBOARD", "KeyDown: AndroidKey:%d Unicode:%d",
           keycode, unicode);


### PR DESCRIPTION
Problem is next. App didn't responds to OK/Enter key. 
After some debugging I found a cause. Remote control along with AKEYCODE_ENTER also sends Line Feed character - 10. So app logic thinks that this is character input.
My patch solves this problem by setting 'unicode' var to zero if 'keycode' is AKEYCODE_ENTER.
OS: Android 4.4.2 (MiTV)
HW: MiBOX mini
