### PR TITLE
Fix endless loop when generating thumbnails on certain files

### DIFF
--- a/src/fileaccess/fa_imageloader.c
+++ b/src/fileaccess/fa_imageloader.c
@@ -586,10 +586,13 @@ fa_image_from_video2(const char *url, const image_meta_t *im,
   }
 
   avcodec_flush_buffers(ifv_ctx);
-
+  
+  int i = 0;
   while(1) {
     int r;
 
+    i++;
+    
     r = av_read_frame(ifv_fctx, &pkt);
 
     if(r == AVERROR(EAGAIN))
@@ -630,6 +633,11 @@ fa_image_from_video2(const char *url, const image_meta_t *im,
       continue;
     }
 
+    // libav seems to have problems seeking on AVC videos encoded with Baseline@L4.0, 1 Ref Frame, (Variable Framerate?), prevent slowdown by endless loop.
+    if (i >= 100){
+      TRACE(TRACE_DEBUG, "Thumb", "Couldn't generate thumbnail for %s", url);
+      break;
+    }
 
     if(got_pic == 0 || !want_pic) {
       continue;


### PR DESCRIPTION
For some weirdly encoded files, the video thumbnail generator gets stuck in the loop, resulting in heavy load on the CPU.

Sloppy workaround is to skip files after 100 tries.

Tried to create a custom sample based on the codec settings from these files, couldn't recreate one though.

I could remux part of a file to provide a sample, it's a WEB-DL of some adult content though.

Mediainfo of one of those files:

General
Complete name : /home/daren/thumb_sample.mov
Format : MPEG-4
Format profile : Base Media
Codec ID : isom
File size : 1.95 GiB
Duration : 29mn 50s
Overall bit rate mode : Variable
Overall bit rate : 9 363 Kbps
Writing application : Lavf52.16.0
Comment : FlixEngineLinux_8.0.14.0 (www.on2.com)

Video
ID : 1
Format : AVC
Format/Info : Advanced Video Codec
Format profile : Baseline@L4.0
Format settings, CABAC : No
Format settings, ReFrames : 1 frame
Format settings, GOP : M=1, N=20
Codec ID : avc1
Codec ID/Info : Advanced Video Coding
Duration : 29mn 50s
Bit rate : 9 229 Kbps
Width : 1 920 pixels
Height : 1 080 pixels
Display aspect ratio : 16:9
Frame rate : 29.970 fps
Color space : YUV
Chroma subsampling : 4:2:0
Bit depth : 8 bits
Scan type : Progressive
Bits/(Pixel*Frame) : 0.149
Stream size : 1.92 GiB (99%)

Audio
ID : 2
Format : AAC
Format/Info : Advanced Audio Codec
Format profile : LC
Codec ID : 40
Duration : 29mn 50s
Bit rate mode : Variable
Bit rate : 128 Kbps
Channel(s) : 2 channels
Channel positions : Front: L R
Sampling rate : 48.0 KHz
Compression mode : Lossy
Stream size : 27.3 MiB (1%)