### PR TITLE
Security Enhancement: Added TLSv1.2 support

### DIFF
--- a/src/networking/net_openssl.c
+++ b/src/networking/net_openssl.c
@@ -136,7 +136,7 @@ net_ssl_init(void)
 {
   SSL_library_init();
   SSL_load_error_strings();
-  app_ssl_ctx = SSL_CTX_new(TLSv1_client_method());
+  app_ssl_ctx = SSL_CTX_new(TLSv1_2_client_method()); /* added TLSv1.2 */
 
   int i, n = CRYPTO_num_locks();
   ssl_locks = malloc(sizeof(pthread_mutex_t) * n);

--- a/src/networking/net_polarssl.c
+++ b/src/networking/net_polarssl.c
@@ -133,6 +133,7 @@ tcp_ssl_open(tcpcon_t *tc, char *errbuf, size_t errlen, const char *hostname)
     ssl_set_hostname(tc->ssl, hostname);
 
   ssl_set_min_version(tc->ssl, SSL_MAJOR_VERSION_3, SSL_MINOR_VERSION_1);
+  ssl_set_max_version(tc->ssl, SSL_MAJOR_VERSION_3, SSL_MINOR_VERSION_3); /* added TLSv1.2 */
   ssl_set_arc4_support(tc->ssl, SSL_ARC4_DISABLED );
 
   ssl_set_rng(tc->ssl, ctr_drbg_random, tc->rndstate);


### PR DESCRIPTION
TLS v1.2 is the up to date way to handle HTTPS connections. This patch adds support for it without breaking support for lower versions.

Tested on/with:
- PC/Ubuntu 14.04 x64 (OpenSSL +  PolarSSL): movian.tv / mrmobo.de
- PS3/Rebug 4.76 (PolarSSL): movian.tv / mrmobo.de

