### PR TITLE
Few fixes for 'lostfilm' plugin

### DIFF
--- a/src/backend/bittorrent/bt_backend.c
+++ b/src/backend/bittorrent/bt_backend.c
@@ -326,10 +326,7 @@ bt_playvideo(const char *url, media_pipe_t *mp,
   torrent_retain(to);
   hts_mutex_unlock(&bittorrent_mutex);
 
-  video_args_t va = *va0;
-  va.canonical_url = newurl;
-
-  event_t *e = backend_play_video(newurl, mp, errbuf, errlen, vq, vsl, &va);
+  event_t *e = backend_play_video(newurl, mp, errbuf, errlen, vq, vsl, va0);
 
   hts_mutex_lock(&bittorrent_mutex);
   torrent_release(to);

--- a/src/ecmascript/es_string.c
+++ b/src/ecmascript/es_string.c
@@ -116,7 +116,9 @@ es_utf8_from_bytes_duk(duk_context *duk)
 
   const char *csname = duk_safe_to_string(duk, 1);
 
-  if(!strcasecmp(csname, "utf-8") || !strcasecmp(csname, "utf8")) {
+  if(!strcasecmp(csname, "\"utf-8\"") ||
+     !strcasecmp(csname, "utf-8") ||
+     !strcasecmp(csname, "utf8")) {
 
     duk_push_lstring(duk, bytes, size);
     const char *str = duk_require_string(duk, -1);


### PR DESCRIPTION
- bt_backend:more convenient canonical_url: from my point of view it is more convenient to use 'canonical_url' provided by plugin, not those one constructed dynamically. also, new constructed url passed to backend_play_video, so probably it is possible to update playing count for both urls.
- es_string: fix for "utf-8" encoding: I'm experiencing error with handling one URL because it returns charset as "utf-8" (with quotes). it would be nice if you know a better way to fix that :)