### PR TITLE
added buffers for http postdata

### DIFF
--- a/src/ecmascript/es_io.c
+++ b/src/ecmascript/es_io.c
@@ -340,7 +340,15 @@ es_http_req(duk_context *ctx)
 
   duk_get_prop_string(ctx, 1, "postdata");
 
-  if(duk_is_object(ctx, -1)) {
+  if(duk_is_buffer(ctx, -1)) {
+    duk_size_t len;
+    unsigned char *buf;
+    buf = (unsigned char *) duk_get_buffer(ctx, -1, &len);
+    ehr->ehr_postdata = malloc(sizeof(htsbuf_queue_t));
+    htsbuf_queue_init(ehr->ehr_postdata, 0);
+    htsbuf_append(ehr->ehr_postdata, buf, len);
+    ehr->ehr_postcontenttype =  strdup("text/plain");
+  } else if(duk_is_object(ctx, -1)) {
     const char *prefix = "";
 
     ehr->ehr_postdata = malloc(sizeof(htsbuf_queue_t));

--- a/src/ecmascript/es_io.c
+++ b/src/ecmascript/es_io.c
@@ -347,7 +347,7 @@ es_http_req(duk_context *ctx)
     ehr->ehr_postdata = malloc(sizeof(htsbuf_queue_t));
     htsbuf_queue_init(ehr->ehr_postdata, 0);
     htsbuf_append(ehr->ehr_postdata, buf, len);
-    ehr->ehr_postcontenttype =  strdup("text/plain");
+    ehr->ehr_postcontenttype = strdup("application/octet-stream");
   } else if(duk_is_object(ctx, -1)) {
     const char *prefix = "";
 
@@ -380,7 +380,7 @@ es_http_req(duk_context *ctx)
     ehr->ehr_postdata = malloc(sizeof(htsbuf_queue_t));
     htsbuf_queue_init(ehr->ehr_postdata, 0);
     htsbuf_append(ehr->ehr_postdata, str, len);
-    ehr->ehr_postcontenttype =  strdup("text/plain");
+    ehr->ehr_postcontenttype = strdup("text/plain");
   } else {
 
   }


### PR DESCRIPTION
Hi, this patch makes it possible to add a Duktape.Buffer as postdata. This is important for application/x-amf requests. I'll post a working example here in a few days when it's ready.

Greetings =)