### PR TITLE
Ecmascript function to test plugin routes

### DIFF
--- a/src/ecmascript/es_route.c
+++ b/src/ecmascript/es_route.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2007-2015 Lonelycoder AB
+ *  Copyright (C) 2007-2018 Lonelycoder AB
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -160,6 +160,31 @@ es_route_create(duk_context *ctx)
 /**
  *
  */
+static int
+es_route_test(duk_context *ctx)
+{
+  const char *str = duk_safe_to_string(ctx, 0);
+
+  hts_mutex_lock(&route_mutex);
+
+  es_route_t *er;
+  hts_regmatch_t matches[8];
+
+  LIST_FOREACH(er, &routes, er_link)
+    if(!hts_regexec(&er->er_regex, str, 8, matches))
+      break;
+
+  duk_push_boolean(ctx, er != NULL);
+
+  hts_mutex_unlock(&route_mutex);
+
+  return 1;
+}
+
+
+/**
+ *
+ */
 int
 ecmascript_openuri(prop_t *page, const char *url, int sync)
 {
@@ -254,6 +279,7 @@ es_backend_open(duk_context *ctx)
 static const duk_function_list_entry fnlist_route[] = {
   { "create",                  es_route_create,      2 },
   { "backendOpen",             es_backend_open,      3 },
+  { "test",                    es_route_test,        1 },
   { NULL, NULL, 0}
 };
 


### PR DESCRIPTION
Hi,

many plugins offer videos hosted on multiple one click hosters such as streamcloud etc. and every plugin contains it's own code to handle those hosters, they often change so some are working and some not. At the moment I'm writing a plugin meant as "shared library" with code that handles different one click hosters. So those hoster code should be fixed ONCE to work in all other plugins depending on that library plugin. It is possible to define routes for the hosters urls in Movian, but it was not possible to check if a matching route for a string exists. (At first I thought the "probe" function does this, but it turns out it doesn't) So the plugins can't check if the hoster is supportet by an external plugin like mine. For that reason I added this functionalty in the "native/route" module. This way a plugin can even define a dummy route like "myplugin:isinstalled" which can be checked by another plugin that depends on the "library plugin".