### PR TITLE
kB/s instead of kb/s

### DIFF
--- a/glwskins/flat/loading.view
+++ b/glwskins/flat/loading.view
@@ -28,7 +28,7 @@ widget(container_y, {
 
       widget(label, {
         filterConstraintX: true;
-        caption: fmt(_("%d kb/s"), $nav.currentpage.model.io.bitrate);
+        caption: fmt(_("%d kB/s"), $nav.currentpage.model.io.bitrate);
       });
     });
 

--- a/glwskins/old/loading.view
+++ b/glwskins/old/loading.view
@@ -34,7 +34,7 @@ widget(container_y, {
         filterConstraintX: true;
         shadow: true;
         outline: true;
-        caption: fmt(_("%d kb/s"), $nav.currentpage.model.io.bitrate);
+        caption: fmt(_("%d kB/s"), $nav.currentpage.model.io.bitrate);
       });
     });
 

--- a/lang/cs_CZ.lang
+++ b/lang/cs_CZ.lang
@@ -131,7 +131,7 @@ msg:
 #
 # ./glwskins/flat/loading.view
 #
-id: %d kb/s
+id: %d kB/s
 # Missing translation
 msg: 
 

--- a/lang/de_DE.lang
+++ b/lang/de_DE.lang
@@ -123,8 +123,8 @@ msg:
 #
 # ./glwskins/flat/loading.view
 #
-id: %d kb/s
-msg: %d kb/s
+id: %d kB/s
+msg: %d kB/s
 
 id: Bitrate:
 msg: Bitrate:

--- a/lang/dk_DK.lang
+++ b/lang/dk_DK.lang
@@ -129,8 +129,8 @@ msg:
 #
 # ./glwskins/flat/loading.view
 #
-id: %d kb/s
-msg: %d kb/s
+id: %d kB/s
+msg: %d kB/s
 
 id: Bitrate:
 # Missing translation

--- a/lang/el_EL.lang
+++ b/lang/el_EL.lang
@@ -128,8 +128,8 @@ msg:
 #
 # ./glwskins/flat/loading.view
 #
-id: %d kb/s
-msg: %d kb/s
+id: %d kB/s
+msg: %d kB/s
 
 id: Bitrate:
 msg: Ρυθμός μετάδοσης:

--- a/lang/fi_FI.lang
+++ b/lang/fi_FI.lang
@@ -128,8 +128,8 @@ msg:
 #
 # ./glwskins/flat/loading.view
 #
-id: %d kb/s
-msg: %d kb/s
+id: %d kB/s
+msg: %d kB/s
 
 id: Bitrate:
 msg: Bitrate:

--- a/lang/fr_FR.lang
+++ b/lang/fr_FR.lang
@@ -121,8 +121,8 @@ msg: Episode %d - %s
 #
 # ./glwskins/flat/loading.view
 #
-id: %d kb/s
-msg: %d kb/s
+id: %d kB/s
+msg: %d kB/s
 
 id: Bitrate:
 msg: Bitrate:

--- a/lang/hu_HU.lang
+++ b/lang/hu_HU.lang
@@ -118,8 +118,8 @@ msg: Epizód %d - %s
 #
 # ./glwskins/flat/loading.view
 #
-id: %d kb/s
-msg: %d kb/s
+id: %d kB/s
+msg: %d kB/s
 
 id: Bitrate:
 msg: Bitráta:

--- a/lang/it_IT.lang
+++ b/lang/it_IT.lang
@@ -128,8 +128,8 @@ msg:
 #
 # ./glwskins/flat/loading.view
 #
-id: %d kb/s
-msg: %d kb/s
+id: %d kB/s
+msg: %d kB/s
 
 id: Bitrate:
 msg: Bitrate:

--- a/lang/ja_JP.lang
+++ b/lang/ja_JP.lang
@@ -128,8 +128,8 @@ msg:
 #
 # ./glwskins/flat/loading.view
 #
-id: %d kb/s
-msg: %d kb/s
+id: %d kB/s
+msg: %d kB/s
 
 id: Bitrate:
 msg: ビットレート:

--- a/lang/mk_MK.lang
+++ b/lang/mk_MK.lang
@@ -117,8 +117,8 @@ msg: Епизода %d - %s
 #
 # ./glwskins/flat/loading.view
 #
-id: %d kb/s
-msg: %d kb/s
+id: %d kB/s
+msg: %d kB/s
 
 id: Bitrate:
 msg: Брзина:

--- a/lang/nl_NL.lang
+++ b/lang/nl_NL.lang
@@ -129,7 +129,7 @@ msg:
 #
 # ./glwskins/flat/loading.view
 #
-id: %d kb/s
+id: %d kB/s
 # Missing translation
 msg: 
 

--- a/lang/pl_PL.lang
+++ b/lang/pl_PL.lang
@@ -116,8 +116,8 @@ msg: Odcinek %d - %s
 #
 # ./glwskins/flat/loading.view
 #
-id: %d kb/s
-msg: %d kb/s
+id: %d kB/s
+msg: %d kB/s
 
 id: Bitrate:
 msg: Bitrate:

--- a/lang/pt_BR.lang
+++ b/lang/pt_BR.lang
@@ -129,7 +129,7 @@ msg:
 #
 # ./glwskins/flat/loading.view
 #
-id: %d kb/s
+id: %d kB/s
 # Missing translation
 msg: 
 

--- a/lang/pt_PT.lang
+++ b/lang/pt_PT.lang
@@ -128,8 +128,8 @@ msg:
 #
 # ./glwskins/flat/loading.view
 #
-id: %d kb/s
-msg: %d kb/s
+id: %d kB/s
+msg: %d kB/s
 
 id: Bitrate:
 msg: Bitrate:

--- a/lang/ru_RU.lang
+++ b/lang/ru_RU.lang
@@ -118,7 +118,7 @@ msg: Эпизод %d - %s
 #
 # ./glwskins/flat/loading.view
 #
-id: %d kb/s
+id: %d kB/s
 msg: %d кб/с
 
 id: Bitrate:

--- a/lang/sp_SP.lang
+++ b/lang/sp_SP.lang
@@ -128,8 +128,8 @@ msg:
 #
 # ./glwskins/flat/loading.view
 #
-id: %d kb/s
-msg: %d kb/s
+id: %d kB/s
+msg: %d kB/s
 
 id: Bitrate:
 msg: Calidad:

--- a/lang/sv_SV.lang
+++ b/lang/sv_SV.lang
@@ -116,8 +116,8 @@ msg: Episod %d - %s
 #
 # ./glwskins/flat/loading.view
 #
-id: %d kb/s
-msg: %d kb/s
+id: %d kB/s
+msg: %d kB/s
 
 id: Bitrate:
 msg: Bithastighet:

--- a/lang/ua_UA.lang
+++ b/lang/ua_UA.lang
@@ -128,7 +128,7 @@ msg:
 #
 # ./glwskins/flat/loading.view
 #
-id: %d kb/s
+id: %d kB/s
 msg: %d кб/с
 
 id: Bitrate:

--- a/lang/zh_CN.lang
+++ b/lang/zh_CN.lang
@@ -117,8 +117,8 @@ msg: 第%d集 - %s
 #
 # ./glwskins/flat/loading.view
 #
-id: %d kb/s
-msg: %d kb/s
+id: %d kB/s
+msg: %d kB/s
 
 id: Bitrate:
 msg: 码率


### PR DESCRIPTION
Hi,

I don't want to play the smartass :mortar_board: but isn't this download rate measured in kilo**Bytes**? Correct me if I'm wrong.

And with this change we may need a new lang file entry (`%d kb/s`) for `mediainfo.view` because I think there we do have Bits, correct?