### PR TITLE
Fix interlaced videos not to show only top half of the video while using videotoolbox

### DIFF
--- a/src/video/h264_annexb.c
+++ b/src/video/h264_annexb.c
@@ -246,7 +246,7 @@ hata_sps(h264_annexb_to_avc_t *hata, const uint8_t *data, int len)
 
   free(hata->sps[sps_id].data);
   hata->sps[sps_id].width  = sps.mb_width  * 16;
-  hata->sps[sps_id].height = sps.mb_height * 16;
+  hata->sps[sps_id].height = sps.mb_height * 16 * (2 - sps.mbs_only_flag);
   hata->sps[sps_id].data = malloc(len);
   hata->sps[sps_id].len = len;
   memcpy(hata->sps[sps_id].data, data, len);


### PR DESCRIPTION
If hardware accelerated decoding is used on Mac OS, interlaced H.264 videos only showing top half of its height.

Attached image is showing the difference between before and after this patch.
<img width="1725" alt="screen shot 2018-08-28 at 11 14 13 pm" src="https://user-images.githubusercontent.com/329456/44731024-3cf6ab00-ab1d-11e8-9923-025ac6e748e6.png">
