### PR TITLE
Optional subdirectory for bookmarks

### DIFF
--- a/lang/cs_CZ.lang
+++ b/lang/cs_CZ.lang
@@ -1446,6 +1446,10 @@ msg: URL
 id: Video
 msg: Video
 
+id: Show bookmarks in a subdirectory
+# Missing translation
+msg: 
+
 #
 # ./src/networking/connman.c
 #

--- a/lang/de_DE.lang
+++ b/lang/de_DE.lang
@@ -1285,6 +1285,9 @@ msg: URL
 id: Video
 msg: Video
 
+id: Show bookmarks in a subdirectory
+msg: Lesezeichen in Unterverzeichnis anzeigen
+
 #
 # ./src/networking/connman.c
 #

--- a/lang/dk_DK.lang
+++ b/lang/dk_DK.lang
@@ -1354,6 +1354,10 @@ msg: URL
 id: Video
 msg: Video
 
+id: Show bookmarks in a subdirectory
+# Missing translation
+msg: 
+
 #
 # ./src/networking/connman.c
 #

--- a/lang/el_EL.lang
+++ b/lang/el_EL.lang
@@ -1342,6 +1342,10 @@ msg: URL
 id: Video
 msg: Βίντεο
 
+id: Show bookmarks in a subdirectory
+# Missing translation
+msg: 
+
 #
 # ./src/networking/connman.c
 #

--- a/lang/fi_FI.lang
+++ b/lang/fi_FI.lang
@@ -1341,6 +1341,10 @@ msg: URL
 id: Video
 msg: Video
 
+id: Show bookmarks in a subdirectory
+# Missing translation
+msg: 
+
 #
 # ./src/networking/connman.c
 #

--- a/lang/fr_FR.lang
+++ b/lang/fr_FR.lang
@@ -1268,6 +1268,10 @@ msg: URL
 id: Video
 msg: Vidéo
 
+id: Show bookmarks in a subdirectory
+# Missing translation
+msg: 
+
 #
 # ./src/networking/connman.c
 #

--- a/lang/hu_HU.lang
+++ b/lang/hu_HU.lang
@@ -1236,6 +1236,10 @@ msg: URL
 id: Video
 msg: Videó
 
+id: Show bookmarks in a subdirectory
+# Missing translation
+msg: 
+
 #
 # ./src/networking/connman.c
 #

--- a/lang/it_IT.lang
+++ b/lang/it_IT.lang
@@ -1297,6 +1297,10 @@ msg: URL
 id: Video
 msg: Video
 
+id: Show bookmarks in a subdirectory
+# Missing translation
+msg: 
+
 #
 # ./src/networking/connman.c
 #

--- a/lang/ja_JP.lang
+++ b/lang/ja_JP.lang
@@ -1307,6 +1307,10 @@ msg: URL
 id: Video
 msg: ビデオ
 
+id: Show bookmarks in a subdirectory
+# Missing translation
+msg: 
+
 #
 # ./src/networking/connman.c
 #

--- a/lang/mk_MK.lang
+++ b/lang/mk_MK.lang
@@ -1240,6 +1240,10 @@ msg: URL
 id: Video
 msg: Видео
 
+id: Show bookmarks in a subdirectory
+# Missing translation
+msg: 
+
 #
 # ./src/networking/connman.c
 #

--- a/lang/nl_NL.lang
+++ b/lang/nl_NL.lang
@@ -1430,6 +1430,10 @@ msg: URL
 id: Video
 msg: Video
 
+id: Show bookmarks in a subdirectory
+# Missing translation
+msg: 
+
 #
 # ./src/networking/connman.c
 #

--- a/lang/pl_PL.lang
+++ b/lang/pl_PL.lang
@@ -1233,6 +1233,10 @@ msg: Adres URL
 id: Video
 msg: Video
 
+id: Show bookmarks in a subdirectory
+# Missing translation
+msg: 
+
 #
 # ./src/networking/connman.c
 #

--- a/lang/pt_BR.lang
+++ b/lang/pt_BR.lang
@@ -1430,6 +1430,10 @@ msg: URL
 id: Video
 msg: Video
 
+id: Show bookmarks in a subdirectory
+# Missing translation
+msg: 
+
 #
 # ./src/networking/connman.c
 #

--- a/lang/pt_PT.lang
+++ b/lang/pt_PT.lang
@@ -1341,6 +1341,10 @@ msg: Endereço
 id: Video
 msg: Vídeo
 
+id: Show bookmarks in a subdirectory
+# Missing translation
+msg: 
+
 #
 # ./src/networking/connman.c
 #

--- a/lang/ru_RU.lang
+++ b/lang/ru_RU.lang
@@ -1238,6 +1238,10 @@ msg: URL
 id: Video
 msg: Видео
 
+id: Show bookmarks in a subdirectory
+# Missing translation
+msg: 
+
 #
 # ./src/networking/connman.c
 #

--- a/lang/sk_SK.lang
+++ b/lang/sk_SK.lang
@@ -1238,6 +1238,10 @@ msg: URL adresa
 id: Video
 msg: Video
 
+id: Show bookmarks in a subdirectory
+# Missing translation
+msg: 
+
 #
 # ./src/networking/connman.c
 #

--- a/lang/sp_SP.lang
+++ b/lang/sp_SP.lang
@@ -1341,6 +1341,10 @@ msg: URL
 id: Video
 msg: Vídeo
 
+id: Show bookmarks in a subdirectory
+# Missing translation
+msg: 
+
 #
 # ./src/networking/connman.c
 #

--- a/lang/sv_SV.lang
+++ b/lang/sv_SV.lang
@@ -1233,6 +1233,10 @@ msg: URL
 id: Video
 msg: Video
 
+id: Show bookmarks in a subdirectory
+# Missing translation
+msg: 
+
 #
 # ./src/networking/connman.c
 #

--- a/lang/ua_UA.lang
+++ b/lang/ua_UA.lang
@@ -1341,6 +1341,10 @@ msg: URL
 id: Video
 msg: Відео
 
+id: Show bookmarks in a subdirectory
+# Missing translation
+msg: 
+
 #
 # ./src/networking/connman.c
 #

--- a/lang/zh_CN.lang
+++ b/lang/zh_CN.lang
@@ -1234,6 +1234,10 @@ msg: URL
 id: Video
 msg: 视频
 
+id: Show bookmarks in a subdirectory
+# Missing translation
+msg: 
+
 #
 # ./src/networking/connman.c
 #


### PR DESCRIPTION
Hi,
I made a new small feature. Bookmarks are shown on the homescreen mixed with the plugins. It can be much stuff if you have many plugins/bookmarks. With this patch you can enable a subdirectory for bookmarks shown on the homescreen instead of all the bookmarks. I think this more "tidy". It can be turned on and off in the settings (off by default) so the user can decide what he prefers.