### PR TITLE
Fixed a bug in fa_makedir_p()

### DIFF
--- a/src/fileaccess/fileaccess.c
+++ b/src/fileaccess/fileaccess.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2007-2015 Lonelycoder AB
+ *  Copyright (C) 2007-2019 Lonelycoder AB
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -1149,9 +1149,12 @@ fa_makedir_p(fa_protocol_t *fap, const char *path)
     memcpy(p, path, l);
     p[l--] = 0;
 
+    if (p[l] == '/')
+      p[l] = 0;
+
     for(; l >= 0; l--)
       if(p[l] == '/')
-	break;
+        break;
     if(l == 0)
       return FAP_NOENT;
 


### PR DESCRIPTION
Hi,
in `fa_makedir_p()` is a recursion, the for loop strips the last element of the path. This fails if the path ends with a slash. The bug can be triggered with the ecmascript `fs.copyfile()` function, I attached a small example plugin. If this plugin is executed the `fa_makedir_p()` function will be called with `/home/xyz/.hts/showtime/testbug/copy/` the for loop just cuts the last '/' so the recursion will be called with `/home/xyz/.hts/showtime/testbug/copy`. The directorys will be created, but the function fails with -6 (file exists) because it trys to create the "copy" directory twice. The patch removes the terminating '/' before executing the for loop to fix this problem.

Example plugin:

plugin.json
```json
{
  "apiversion": 2,
  "type": "ecmascript",
  "id": "testbug",
  "file": "testbug.js",
  "title": "Testing the bug"
}
```

```javascript
var MANIFEST = JSON.parse(Plugin.manifest)
require('showtime/service').create(MANIFEST.title, MANIFEST.id + ':start', 'video', true, 'dataroot://res/svg/Archive.svg')

var page = require('showtime/page')
var fs = require('native/fs')

new page.Route(MANIFEST.id + ':start', function(page) {
  // Set metadata (type, title, icon)
  page.type = 'directory'
  page.metadata.title = MANIFEST.title
  page.metadata.icon = 'dataroot://res/svg/Archive.svg'

  // If there is no plugin directory in ~/.hts/showtime/plugins the bug will trigger, the directory
  // will be created on the first (failing) try and the second one will work. Delete the directory
  // to trigger the bug again.
  
  console.log(fs.copyfile(Plugin.path + 'plugin.json', 'plugin.json'))
})
```