### PR TITLE
Add HEVC codec support for HTSP (TV) streams

### DIFF
--- a/src/backend/htsp/htsp.c
+++ b/src/backend/htsp/htsp.c
@@ -2352,6 +2352,10 @@ htsp_subscriptionStart(htsp_connection_t *hc, htsmsg_t *m)
 	nicename = "H264";
 	mcp.cheat_for_speed = 1;
         mcp.broken_aud_placement = 1;
+      } else if(!strcmp(type, "HEVC")) {
+	codec_id = AV_CODEC_ID_HEVC;
+	media_type = MEDIA_TYPE_VIDEO;
+	nicename = "HEVC";
       } else if(!strcmp(type, "DVBSUB")) {
 	codec_id = AV_CODEC_ID_DVB_SUBTITLE;
 	media_type = MEDIA_TYPE_SUBTITLE;


### PR DESCRIPTION
Pretty simple `else if` addition.
HEVC is used by e.g. German HD TV via DVB-T2.